### PR TITLE
PHP extension updates

### DIFF
--- a/root-files/opt/flownative/php/build/extensions/imagick/imagick.sh
+++ b/root-files/opt/flownative/php/build/extensions/imagick/imagick.sh
@@ -42,7 +42,7 @@ extensions_imagick_runtime_packages() {
 # @return string
 #
 extensions_imagick_url() {
-    echo "https://pecl.php.net/get/imagick-3.4.4.tgz"
+    echo "https://pecl.php.net/get/imagick-3.5.1.tgz"
 }
 
 # ---------------------------------------------------------------------------------------

--- a/root-files/opt/flownative/php/build/extensions/phpredis/phpredis.sh
+++ b/root-files/opt/flownative/php/build/extensions/phpredis/phpredis.sh
@@ -39,7 +39,7 @@ extensions_phpredis_runtime_packages() {
 # @return string
 #
 extensions_phpredis_url() {
-    echo "https://github.com/phpredis/phpredis/archive/5.3.3.tar.gz"
+    echo "https://github.com/phpredis/phpredis/archive/5.3.4.tar.gz"
 }
 
 # ---------------------------------------------------------------------------------------

--- a/root-files/opt/flownative/php/build/extensions/phpredis/phpredis.sh
+++ b/root-files/opt/flownative/php/build/extensions/phpredis/phpredis.sh
@@ -39,7 +39,7 @@ extensions_phpredis_runtime_packages() {
 # @return string
 #
 extensions_phpredis_url() {
-    echo "https://github.com/phpredis/phpredis/archive/5.1.1.tar.gz"
+    echo "https://github.com/phpredis/phpredis/archive/5.3.3.tar.gz"
 }
 
 # ---------------------------------------------------------------------------------------

--- a/root-files/opt/flownative/php/build/extensions/vips/vips.sh
+++ b/root-files/opt/flownative/php/build/extensions/vips/vips.sh
@@ -37,7 +37,7 @@ extensions_vips_runtime_packages() {
 # @return string
 #
 extensions_vips_url() {
-    echo "https://github.com/jcupitt/php-vips-ext/raw/master/vips-1.0.10.tgz"
+    echo "https://github.com/jcupitt/php-vips-ext/raw/master/vips-1.0.12.tgz"
 }
 
 # ---------------------------------------------------------------------------------------

--- a/root-files/opt/flownative/php/build/extensions/yaml/yaml.sh
+++ b/root-files/opt/flownative/php/build/extensions/yaml/yaml.sh
@@ -39,7 +39,7 @@ extensions_yaml_runtime_packages() {
 # @return string
 #
 extensions_yaml_url() {
-    echo "http://pecl.php.net/get/yaml-2.0.4.tgz"
+    echo "http://pecl.php.net/get/yaml-2.2.1.tgz"
 }
 
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Updates to PHP extensions

- phpredis 5.1.1 to 5.3.4
- vips 1.0.10 to 1.0.12
- yaml 2.0.4 to 2.2.1
- imagick 3.4.4 to 3.5.1