### PR TITLE
Include PHP extension "SSH2"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN export FLOWNATIVE_LOG_PATH_AND_FILENAME=/dev/stdout \
     && /build.sh build_extension phpredis \
     && /build.sh build_extension xdebug \
     && /build.sh disable_extension xdebug \
+    && /build.sh build_extension ssh2 \
     && /build.sh clean
 
 USER 1000

--- a/root-files/opt/flownative/php/build/extensions/ssh2/ssh2.sh
+++ b/root-files/opt/flownative/php/build/extensions/ssh2/ssh2.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+
+# ---------------------------------------------------------------------------------------
+# extensions_ssh2_prepare() - Prepare the system for this extension
+#
+# @return List of packages
+#
+extensions_ssh2_prepare() {
+    echo ""
+}
+
+# ---------------------------------------------------------------------------------------
+# extensions_ssh2_build_packages() - List package names only needed during build time
+#
+# @return List of packages
+#
+extensions_ssh2_build_packages() {
+    local packages="libssl-dev libssh2-1-dev"
+    echo $packages
+}
+
+# ---------------------------------------------------------------------------------------
+# extensions_ssh2_runtime_packages() - List package names needed during runtime
+#
+# @return List of packages
+#
+extensions_ssh2_runtime_packages() {
+    echo ""
+}
+
+# ---------------------------------------------------------------------------------------
+# extensions_ssh2_url() - Returns the URL leading to the source code archive
+#
+# For new releases see: https://pecl.php.net/package/ssh2
+#
+# @return string
+#
+extensions_ssh2_url() {
+     echo "https://pecl.php.net/get/ssh2-1.3.1.tgz"
+}
+
+# ---------------------------------------------------------------------------------------
+# extensions_ssh2_configure_arguments() - Returns additional configure arguments
+#
+# @return string
+#
+extensions_ssh2_configure_arguments() {
+    echo ""
+}


### PR DESCRIPTION
This change includes the SSH2 extension and enables it by default.

For documentation see https://www.php.net/manual/en/book.ssh2.php

Resolves #15