### PR TITLE
Improve Xdebug configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ services:
       - NGINX_PHP_FPM_HOST=app_php.local_beach
 
   php:
-    image: flownative/php:8.1
+    image: flownative/php:8.2
     volumes:
       - application:/application
     environment:
@@ -77,8 +77,10 @@ similar mechanism in Kubernetes or your actual platform.
 | PHP_MEMORY_LIMIT                | string  | 750M                                   | PHP memory limit ([doc](https://www.php.net/manual/en/ini.core.php#ini.memory-limit))                                                               |
 | PHP_OPCACHE_PRELOAD             | string  |                                        | Path and filename of a preload script ([doc](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.preload))                          |
 | PHP_XDEBUG_ENABLE               | boolean | false                                  | Enable or disable the Xdebug extension                                                                                                              |
+| PHP_XDEBUG_MODE                 | string  | develop                                | Controls which Xdebug features are enabled, for example "develop" or "debug". See Xdebug manual for details                                         |
+| PHP_XDEBUG_CONFIG               | string  |                                        | Values assigned to this variable are propagated as XDEBUG_CONFIG. See Xdebug manual for details                                                     |
 | PHP_XDEBUG_DISCOVER_CLIENT_HOST | boolean | false                                  | If enabled, Xdebug will first try to connect to the client that made the HTTP request. See Xdebug manual for details                                |
-| PHP_XDEBUG_CLIENT_HOST          | string  | host.xdebug.beach                      | Configures the IP address or hostname where Xdebug will attempt to connect to when initiating a debugging connection. See Xdebug manual for details |
+| PHP_XDEBUG_CLIENT_HOST          | string  |                                        | Configures the IP address or hostname where Xdebug will attempt to connect to when initiating a debugging connection. See Xdebug manual for details |
 | PHP_XDEBUG_MAX_NESTING_LEVEL    | integer | 512                                    | Controls the protection mechanism for infinite recursion protection. See Xdebug manual for details                                                  |
 | PHP_IGBINARY_ENABLE             | boolean | false                                  | Enable or disable the igbinary extension                                                                                                            |
 | PHP_FPM_USER                    | string  | 1000                                   | User id for running PHP (read-only)                                                                                                                 |
@@ -100,7 +102,7 @@ you can take advantage of the non-root approach by disallowing privilege
 escalation:
 
 ```yaml
-$ docker run flownative/php:8.1 --security-opt=no-new-privileges
+$ docker run flownative/php:8.2 --security-opt=no-new-privileges
 ```
 
 When you exec into this container running bash, you will notice your
@@ -109,7 +111,7 @@ container runs as a user with uid 1000, but in fact that user does not
 even exist.
 
 ```
-$ docker run -ti --name php --rm flownative/php:8.1 bash
+$ docker run -ti --name php --rm flownative/php:8.2 bash
 I have no name!@5a0adf17e426:/$ whoami
 whoami: cannot find name for user ID 1000
 ```
@@ -121,7 +123,7 @@ version for some of the tools as build arguments:
 
 ```bash
 docker build \
-    --build-arg PHP_VERSION=8.1.4 \
+    --build-arg PHP_VERSION=8.2.4 \
     -t flownative/php:latest .
 ```
 

--- a/root-files/opt/flownative/lib/php-fpm.sh
+++ b/root-files/opt/flownative/lib/php-fpm.sh
@@ -34,8 +34,11 @@ export PHP_ERROR_LOG="${PHP_ERROR_LOG:-/dev/stderr}"
 export PHP_OPCACHE_PRELOAD="${PHP_OPCACHE_PRELOAD:-}"
 
 export PHP_XDEBUG_ENABLE="${PHP_XDEBUG_ENABLE:-false}"
+export PHP_XDEBUG_MODE="${PHP_XDEBUG_MODE:-develop}"
 export PHP_XDEBUG_DISCOVER_CLIENT_HOST="${PHP_XDEBUG_DISCOVER_CLIENT_HOST:-false}"
-export PHP_XDEBUG_CLIENT_HOST="${PHP_XDEBUG_CLIENT_HOST:-host.xdebug.beach}"
+export PHP_XDEBUG_CLIENT_HOST="${PHP_XDEBUG_CLIENT_HOST:-}"
+export PHP_XDEBUG_CONFIG="${PHP_XDEBUG_CONFIG:-}"
+export XDEBUG_CONFIG="${XDEBUG_CONFIG:-${PHP_XDEBUG_CONFIG}}"
 export PHP_XDEBUG_MAX_NESTING_LEVEL="${PHP_XDEBUG_MAX_NESTING_LEVEL:-512}"
 
 export PHP_IGBINARY_ENABLE="${PHP_IGBINARY_ENABLE:-false}"
@@ -80,6 +83,7 @@ php_fpm_initialize() {
         mv "${PHP_CONF_PATH}/conf.d/php-ext-xdebug.ini.inactive" "${PHP_CONF_PATH}/conf.d/php-ext-xdebug.ini"
     else
         info "PHP-FPM: Xdebug is disabled"
+        export PHP_XDEBUG_MODE="off"
     fi
 
     if is_boolean_yes "${PHP_IGBINARY_ENABLE}"; then

--- a/root-files/opt/flownative/php/etc/php.ini
+++ b/root-files/opt/flownative/php/etc/php.ini
@@ -268,7 +268,7 @@ opcache.preload = ${PHP_OPCACHE_PRELOAD}
 [xdebug]
 ; The extension is loaded via /opt/flownative/php/etc/conf.d/php-ext-xdebug.ini, if PHP_XDEBUG_ENABLE is true
 
-xdebug_enable=${PHP_XDEBUG_ENABLE}
+xdebug.mode=${PHP_XDEBUG_MODE}
 xdebug.discover_client_host=${PHP_XDEBUG_DISCOVER_CLIENT_HOST}
 xdebug.client_host=${PHP_XDEBUG_CLIENT_HOST}
 xdebug.max_nesting_level=${PHP_XDEBUG_MAX_NESTING_LEVEL}


### PR DESCRIPTION
Two new Xdebug options were added (PHP_XDEBUG_MODE and PHP_XDEBUG_CONFIG) and the default of PHPH_XDEBUG_CLIENT_HOST was removed, as it did not make any sense in practice. PHP_XDEBUG_MODE is now set to "off" when PHP_XDEBUG_ENABLE is FALSE.