### PR TITLE
Update to use bookworm base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/flownative/docker/base:bullseye
+FROM europe-docker.pkg.dev/flownative/docker/base:bookworm
 
 LABEL org.opencontainers.image.authors="Robert Lemke <robert@flownative.com>"
 

--- a/root-files/build.sh
+++ b/root-files/build.sh
@@ -85,7 +85,7 @@ build_get_runtime_packages() {
         libpq5
         libreadline8
         libsodium-dev
-        libssl1.1
+        libssl3
         libzip4
         libbz2-1.0
         libncurses6
@@ -120,7 +120,7 @@ build_compile_php() {
     php_source_url="https://www.php.net/distributions/php-${PHP_VERSION}.tar.gz"
 
     info "🛠 Downloading source code for PHP ${PHP_VERSION} from ${php_source_url} ..."
-    with_backoff "curl -sSL ${php_source_url} -o php.tar.gz" "15" || (
+    with_backoff "curl -sfSL ${php_source_url} -o php.tar.gz" "15" || (
         error "Failed downloading PHP source from ${php_source_url}"
         exit 1
     )


### PR DESCRIPTION
Adjusts libssl version as the other is no longer available, also adds the f(ail) flag to curl while fetching php sources to avoid downloading a 404 page because the resulting error message is not helpful and we want to know about a failure to download anyways.