### PR TITLE
Update Xdebug to 3.4.1

### DIFF
--- a/root-files/opt/flownative/php/build/extensions/xdebug/xdebug.sh
+++ b/root-files/opt/flownative/php/build/extensions/xdebug/xdebug.sh
@@ -38,7 +38,7 @@ extensions_xdebug_runtime_packages() {
 # @return string
 #
 extensions_xdebug_url() {
-    echo "https://xdebug.org/files/xdebug-3.4.0.tgz"
+    echo "https://xdebug.org/files/xdebug-3.4.1.tgz"
 }
 
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Changes in Xdebug since 3.4.0:

- Fixed bug [#2306](https://bugs.xdebug.org/bug_view_page.php?bug_id=00002306): Segmentation fault on each HTTP request when not listening to debugging connections
- Fixed bug [#2307](https://bugs.xdebug.org/bug_view_page.php?bug_id=00002307): Segmentation fault due to a superglobal being a reference while checking for triggers
- Fixed bug [#2309](https://bugs.xdebug.org/bug_view_page.php?bug_id=00002309): Installation on Windows with PHP PIE failing
- Fixed bug [#2310](https://bugs.xdebug.org/bug_view_page.php?bug_id=00002310): xdebug 3.4.0 crashes php8.1-fpm after script execution