### PR TITLE
Next try on a build cache

### DIFF
--- a/.github/workflows/docker.build.yaml
+++ b/.github/workflows/docker.build.yaml
@@ -14,8 +14,6 @@ jobs:
     strategy:
       matrix:
         php: [ 8.1.31, 8.2.27, 8.3.16, 8.4.3 ]
-    # downgraded from latest (being 24.04) due to https://3.basecamp.com/3923521/buckets/6162023/card_tables/cards/8268321367
-    # runs-on: ubuntu-22.04
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,12 +55,7 @@ jobs:
       - name: Set up QEMU
         id: qemu
         uses: docker/setup-qemu-action@v3
-        # commented, as tonistiigi/binfmt:latest has been updated. Remove, if it works.
-        #with:
-          # setup-qemu-action by default uses tonistiigi/binfmt:latest,
-          # which is out of date, see https://github.com/tonistiigi/binfmt/issues/165.
-          # This causes seg faults during build.
-          #image: tonistiigi/binfmt:qemu-v8.1.5
+
       -
         name: Set up Docker Buildx
         id: buildx
@@ -81,18 +74,44 @@ jobs:
           username: '_json_key'
           password: ${{ secrets.GOOGLE_ARTIFACTS_PASSWORD_DOCKER }}
 
-      - name: Build Docker image
+#      - name: Build Docker image
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: .
+#          platforms: linux/amd64,linux/arm64
+#          push: true
+#          build-args: |
+#            PHP_VERSION=${{ matrix.php }}
+#          tags: ${{ steps.meta.outputs.tags }}
+#          labels: ${{ steps.meta.outputs.labels }}
+#          cache-from: type=gha,scope=php-${{ matrix.php }}-platform-${{ matrix.platform }}
+#          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}-platform-${{ matrix.platform }}
+
+      - name: Build Docker image (ARM)
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           build-args: |
             PHP_VERSION=${{ matrix.php }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=php-${{ matrix.php }}-platform-arm64
+          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}-platform-arm64
+
+      - name: Build Docker image (AMD)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            PHP_VERSION=${{ matrix.php }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=php-${{ matrix.php }}-platform-amd64
+          cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}-platform-amd64
 
   announce:
     runs-on: ubuntu-latest


### PR DESCRIPTION
According to the LLM

> Unfortunately, type=gha caching in multi-platform builds doesn't fully support loading the cache for each platform due to cross-platform architecture differences. But there is a workaround! You can split the cache per platform by running separate builds with distinct scopes for each platform.

Well, let's see.